### PR TITLE
Add CI/CD pipeline with code coverage, linting, and code formatting

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -50,3 +50,19 @@ jobs:
         with:
           upload-snapshots: true
           build_args: 'c("--no-manual","--compact-vignettes=gs+qpdf")'
+
+      - uses: r-lib/actions/setup-r-dependencies@v2
+        with:
+          extra-packages: any::rcmdcheck,covr,lintr,styler
+          needs: check
+  
+      - name: Run test coverage
+        run: Rscript -e 'covr::codecov()'
+        env:
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Run linting
+        run: Rscript -e 'lintr::lint_package()'
+
+      - name: Check code formatting with styler
+        run: Rscript -e 'styler::style_pkg(strict = TRUE, scope = "file", dry_run = TRUE)'


### PR DESCRIPTION
Initiated CI/CD pipeline with [usethis setup](https://usethis.r-lib.org/articles/usethis-setup.html). Added code coverage, linting and code formatting in R-CMD-check.yaml