### PR TITLE
Add logger package dependency

### DIFF
--- a/.Renviron
+++ b/.Renviron
@@ -1,0 +1,1 @@
+_R_CHECK_USE_CODETOOLS_=FALSE # Since we use NSE

--- a/.Renviron
+++ b/.Renviron
@@ -1,1 +1,0 @@
-_R_CHECK_USE_CODETOOLS_=FALSE # Since we use NSE

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,8 @@ Imports:
     future,
     pbapply,
     furrr,
-    parallel
+    parallel,
+    logger
 Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3


### PR DESCRIPTION
Without this, the logger package is missing after installing our package.

Test for the fix:
```
remove.packages("logger")
devtools::install(".")

Rscript scripts/VISS_Sample_Data.R
```
