### PR TITLE
feat: utility function for creating grid from extent, resolution and crs

### DIFF
--- a/utility/format_conversion_util.R
+++ b/utility/format_conversion_util.R
@@ -157,3 +157,40 @@ prepare_climate_data_from_tif <- function(input_file,
 
   return(updated_grid)
 }
+
+#' Create a Spatial Grid as an sf Object
+#'
+#' This function generates a raster grid with a specified extent, resolution,
+#' and coordinate reference system (CRS),
+#' assigns unique IDs to each cell,
+#' and converts it into a simple feature (`sf`) object.
+#'
+#' @param extent_vals A numeric vector of four values specifying the extent
+#' in the format `c(xmin, xmax, ymin, ymax)`. Default is `c(-180, 180, -90, 90)`
+#' @param resolution A numeric value defining grid resolution. Default is `1`
+#' @param crs A character string specifying the coordinate reference system
+#' (CRS) in EPSG format. Default is `"EPSG:4326"`.
+#'
+#' @return An `sf` object representing the spatial grid.
+#' @export
+create_grid <- function(extent_vals = c(-180, 180, -90, 90),
+                        resolution = 1, crs = "EPSG:4326") {
+
+  # Create a raster with the specified extent, resolution, and CRS
+  r <- rast(extent = ext(extent_vals[1],
+                         extent_vals[2],
+                         extent_vals[3],
+                         extent_vals[4]),
+            resolution = resolution,
+            crs = crs)
+
+  # Assign unique IDs to grid cells
+  r$world_id <- 1:ncell(r)
+
+  # Convert raster to an sf object
+  grid <- r %>%
+    st_as_stars() %>%
+    st_as_sf()
+
+  return(grid)
+}


### PR DESCRIPTION
Adding this utility function to handle grid creation as per the discussion below:

Mentioned separately in #71 as a discussion between Carlos and Andreas.

> For the grid input, the current script uses the climate data to define it. Will be it cumbersome to require the climate data for the species pre-processing? In large scale scenarios it may me better to now require the species and climate data to be together until later. Ie we talked about how the preprocessed data can become very small, so its easy to move after the preprocessing. Are there other ways we can define the grid? Ie can the function take some additional arguments to define the grid? (ie bounds+ resolution). This could be either individual arguments or part of a config file like we discussed.
> 
> From Andreas Meyer:
> , yes we can create an empty raster with the same resolution as the climate data, and from that define the grid. The arguments would be the extent, resolution and crs
> r <- rast(extent = ext(-180, 180, -90, 90),
> resolution = 1,
> crs = "EPSG:4326")
> 
> r$world_id <- 1:ncell(r)
> 
> grid <- r %>%
> st_as_stars() %>%
> st_as_sf()