### PR TITLE
fix: docker image name typo

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -115,7 +115,7 @@ Use the provided `Dockerfile` to build the image and update the CONTAINER
 variable with built image name in run_container.sh:
 
 ```bash
-docker build -t biodiversity-horizons .
+docker build -t biodiversityhorizons .
 ```
 
 ### Step 2a: Run the commands on the docker container using run_container.sh

--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ containerized environment, ensuring consistent R dependencies.
 ### 2. Pull the Docker Image
 
 ```
-docker pull ghcr.io/uw-ssec/biodiversity-horizons:latest
+docker pull ghcr.io/uw-ssec/biodiversityhorizons:latest
 ```
 
 If this succeeds, the image is downloaded locally.
@@ -143,19 +143,19 @@ docker run --rm -it --privileged \
 **Step 3: Pull and convert the Docker image into a .sif file for Apptainer**
 
 ```
-apptainer pull /mnt/biodiversity-horizons.sif docker://ghcr.io/uw-ssec/biodiversity-horizons:latest
+apptainer pull /mnt/biodiversityhorizons.sif docker://ghcr.io/uw-ssec/biodiversityhorizons:latest
 ```
 
 **Step 4: Verify the .sif file was created**
 
 ```
-ls -l /mnt/biodiversity-horizons.sif
+ls -l /mnt/biodiversityhorizons.sif
 ```
 
 **Step 5: Run Apptainer shell and mount required directories**
 
 ```
-apptainer shell --bind /mnt/data-raw:/home/biodiversity-horizons/data-raw /mnt/biodiversity-horizons.sif
+apptainer shell --bind /mnt/data-raw:/home/biodiversity-horizons/data-raw /mnt/biodiversityhorizons.sif
 ```
 
 ### Inside Apptainer Shell:

--- a/docs/running_on_hyak.md
+++ b/docs/running_on_hyak.md
@@ -140,7 +140,6 @@ cd /home/biodiversity-horizons
 
 Run with Default Arguments in input_config.yml
 
-
 ```
 Rscript scripts/main.R exposure -i data-raw/input_config.yml
 ```

--- a/docs/running_on_hyak.md
+++ b/docs/running_on_hyak.md
@@ -87,15 +87,15 @@ successful.
 ## Step 4: Pull the .sif Image on Hyak from Container registry
 
 ```
-apptainer pull /gscratch/scrubbed/<<UWNetid>/basics/biodiversity-horizons_latest.sif \
-    docker://ghcr.io/uw-ssec/biodiversity-horizons:latest
+apptainer pull /gscratch/scrubbed/<<UWNetid>/basics/biodiversityhorizons_latest.sif \
+    docker://ghcr.io/uw-ssec/biodiversityhorizons:latest
 ```
 
 Alternatively, try with Singularity:
 
 ```
-singularity pull /gscratch/scrubbed/<<UWNetid>/basics/biodiversity-horizons_latest.sif \
-    docker://ghcr.io/uw-ssec/biodiversity-horizons:latest
+singularity pull /gscratch/scrubbed/<<UWNetid>/basics/biodiversityhorizons_latest.sif \
+    docker://ghcr.io/uw-ssec/biodiversityhorizons:latest
 ```
 
 Verify the download:
@@ -110,14 +110,14 @@ ls -l /gscratch/scrubbed/<UWNetid>/basics/
 
 ```
 apptainer shell --bind /gscratch/scrubbed/<UWNetid>/data-raw:/home/biodiversity-horizons/data-raw \
-    /gscratch/scrubbed/<UWNetid>/basics/biodiversity-horizons_latest.sif
+    /gscratch/scrubbed/<UWNetid>/basics/biodiversityhorizons_latest.sif
 ```
 
 Alternatively, try with Singularity:
 
 ```
 singularity shell --bind /gscratch/scrubbed/<UWNetid>/data-raw:/home/biodiversity-horizons/data-raw \
-    /gscratch/scrubbed/<UWNetid>/basics/biodiversity-horizons_latest.sif
+    /gscratch/scrubbed/<UWNetid>/basics/biodiversityhorizons_latest.sif
 ```
 
 You should now see the `Apptainer>` prompt.
@@ -138,13 +138,8 @@ cd /home/biodiversity-horizons
 
 ## Step 7: Run the R Script
 
-Run with Default Arguments
+Run with Default Arguments in input_config.yml
 
-```
-Rscript scripts/main.R exposure --data data-raw/
-```
-
-Run with Custom Parameters
 
 ```
 Rscript scripts/main.R exposure -i data-raw/input_config.yml

--- a/run_container.sh
+++ b/run_container.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 # CONTAINER=biodiv # for development, change this to the name of your local Docker ccontainer build
-CONTAINER=ghcr.io/uw-ssec/biodiversity-horizons
+CONTAINER=ghcr.io/uw-ssec/biodiversityhorizons
 
 function run_with_mounts() {
 


### PR DESCRIPTION
#116 fix: docker image name typo

The docker image uploaded via the GH action workflow pipeline is built using the Package name in the DESCRIPTION file, which is "biodiversityhorizons," but the code to run the docker container was pulling the image with the name "biodiversity-horizons" (extra '-'). Due to this, the latest image is not being pulled correctly.

- [x] Updated the docker image name based on the 'Package' name provided in the DESCRIPTION file.

