### PR TITLE
feat: MPI Support

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,6 +41,11 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
+      - name: Setup MPI
+        uses: mpi4py/setup-mpi@v1
+        with:
+          mpi: openmpi
+
       - name: Install required R packages
         run: |
           Rscript -e 'install.packages(c("magrittr", "usethis", "roxygen2"))'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -43,8 +43,6 @@ jobs:
 
       - name: Setup MPI
         uses: mpi4py/setup-mpi@v1
-        with:
-          mpi: openmpi
 
       - name: Install required R packages
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -27,7 +27,8 @@ Imports:
     stars,
     arrow,
     stringr,
-    glue
+    glue,
+    pbdMPI,
 Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/uw-ssec/r-bio-div-base:1.2
+FROM ghcr.io/uw-ssec/r-bio-div-base:1.3
 
 
 

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -21,8 +21,12 @@ RUN apt-get update && apt-get install -y \
     squashfs-tools \
     cmake \
     libthrift-dev \
+    openmpi-bin \
+    openmpi-doc \
+    libopenmpi-dev \
     && rm -rf /var/lib/apt/lists/*
 
 RUN Rscript -e "install.packages('terra', repos='https://cloud.r-project.org')"
 RUN Rscript -e "install.packages('remotes', repos='https://cloud.r-project.org')"
 RUN Rscript -e "install.packages('devtools', repos='https://cloud.r-project.org', dependencies=TRUE)"
+RUN Rscript -e "install.packages('pdbMPI', repos='https://cloud.r-project.org')"

--- a/Dockerfile-base
+++ b/Dockerfile-base
@@ -29,4 +29,4 @@ RUN apt-get update && apt-get install -y \
 RUN Rscript -e "install.packages('terra', repos='https://cloud.r-project.org')"
 RUN Rscript -e "install.packages('remotes', repos='https://cloud.r-project.org')"
 RUN Rscript -e "install.packages('devtools', repos='https://cloud.r-project.org', dependencies=TRUE)"
-RUN Rscript -e "install.packages('pdbMPI', repos='https://cloud.r-project.org')"
+RUN Rscript -e "install.packages('pbdMPI', repos='https://cloud.r-project.org')"

--- a/scripts/exposure_workflow.R
+++ b/scripts/exposure_workflow.R
@@ -11,6 +11,7 @@ library(future)
 library(glue)
 library(devtools)
 library(arrow)
+library(pbdMPI)
 
 # Initialize logger
 log_threshold(INFO)
@@ -19,23 +20,35 @@ log_info("Starting unified exposure workflow")
 BIEN_PARQUET_SUFFIX <- "_processed\\.parquet"
 
 exposure_workflow <- function(
-  historical_climate_filepath,
-  future_climate_filepath,
-  species_filepath,
-  species_type,
-  plan_type,
-  workers,
-  exposure_result_file
-) {
+    historical_climate_filepath,
+    future_climate_filepath,
+    species_filepath,
+    species_type,
+    plan_type,
+    workers,
+    exposure_result_file) {
+  # TODO: REMOVE THIS
+  # workers <- NULL
+  # species_type <- "shp"
+  # plan_type <- "multisession"
+  # historical_climate_filepath <- "/Users/carlosg/repos/biodiversity-horizons/data-raw/historical_climate_data_new.rds"
+  # future_climate_filepath <- "/Users/carlosg/repos/biodiversity-horizons/data-raw/future_climate_data_new.rds"
+  # species_filepath <- "/Users/carlosg/repos/biodiversity-horizons/data-raw/species_new.rds"
   if (is.null(workers)) {
     workers <- availableCores() - 1
     log_info("Number of workers not provided. Using {workers} workers.")
   }
 
+  pbdMPI::init()
+  mpi_rank <- comm.rank()
+  mpi_size <- comm.size()
+  log_info("MPI size: {mpi_size}, MPI rank: {mpi_rank}")
+
+
   # Load climate data
   log_info("Loading historical and future climate data...")
   historical_climate_df <- readRDS(historical_climate_filepath)
-  future_climate_df     <- readRDS(future_climate_filepath)
+  future_climate_df <- readRDS(future_climate_filepath)
   log_info("Historical climate data: {nrow(historical_climate_df)} rows")
   log_info("Future climate data: {nrow(future_climate_df)} rows")
 
@@ -52,6 +65,7 @@ exposure_workflow <- function(
     )
 
     species_list <- list()
+    # TODO: For BIEN it may be better to split the files by mpi rank
     for (file in species_files) {
       species_name <- gsub(BIEN_PARQUET_SUFFIX, "", basename(file))
       bien_data <- arrow::read_parquet(file)
@@ -68,6 +82,16 @@ exposure_workflow <- function(
   }
 
   log_info("Loaded {length(species_list)} species.")
+  # Split the species list into chunks based on the number of ranks
+  species_chunks <- split(species_list, seq_along(species_list) %% mpi_size)
+
+  # Assign the chunk corresponding to the current rank
+  species_list <- species_chunks[[mpi_rank + 1]]
+
+  log_info("Rank {mpi_rank} processing {length(species_list)} species.")
+
+  species_chunks <- split(species_list, seq_along(species_list) %% mpi_size)
+  species_list <- species_chunks[[mpi_rank + 1]]
 
   # Load functions
   log_info("Loading package functions...")
@@ -93,7 +117,7 @@ exposure_workflow <- function(
       .progress = TRUE
     )
   }
-  log_info("Thermal limit computation complete.")
+  log_info("Thermal limit computation complete. {nrow(niche_limits)} niche_limits.")
 
   # Calculate exposure
   log_info("Calculating exposure...")
@@ -103,7 +127,7 @@ exposure_workflow <- function(
     .progress = TRUE
   )
   names(exposure_list) <- names(species_list)
-  log_info("Exposure calculation complete.")
+  log_info("Exposure calculation complete. {length(exposure_list)} species processed.")
 
   # Calculate exposure times
   log_info("Calculating exposure times...")
@@ -112,10 +136,13 @@ exposure_workflow <- function(
     mutate(sum = rowSums(select(., starts_with("2")))) %>%
     filter(sum < 82) %>% # Select only cells with < 82 suitable years. TODO: Make this a parameter.
     select(-sum)
+  log_info("{nrow(exposure_df)} rows in exposure_df.")
 
-  cl <- future::makeClusterPSOCK(workers, port = 12000, outfile = NULL, verbose = TRUE)
+  cl <- future::makeClusterPSOCK(workers, port = 12000 + mpi_rank, outfile = NULL, verbose = FALSE)
+  clusterEvalQ(cl, suppressPackageStartupMessages(library(dplyr)))
   clusterEvalQ(cl, library(dplyr))
   clusterExport(cl, "exposure_times")
+
 
   res_final <- pbapply(
     X = exposure_df,
@@ -135,21 +162,41 @@ exposure_workflow <- function(
   stopCluster(cl)
   log_info("Exposure time calculation complete.")
 
-  # Save results
+  combined_results <- list(res_final) # Include rank 0's results
+  if (mpi_rank == 0) {
+    # Rank 0: Receive results from all other ranks
+    log_info("Rank 0 has {nrow(res_final)} results")
+    for (rank in seq_len(mpi_size - 1)) {
+      log_info("Rank 0 waiting to receive results from rank {rank}")
+      received_result <- pbdMPI::recv(rank.source = rank, tag = rank)
+      combined_results[[rank + 1]] <- received_result
+      log_info("Rank 0 received {nrow(received_result)} results from rank {rank}")
+    }
+  } else {
+    # Other ranks: Send results to rank 0
+    log_info("Rank {mpi_rank} sending results to rank 0")
+    pbdMPI::send(res_final, rank.dest = 0, tag = mpi_rank)
+  }
+  # Combine all results into a single data frame
+  final_combined_result <- bind_rows(combined_results) %>% na.omit()
+
+  # Save the combined result
   output_dir <- "outputs"
   if (!dir.exists(output_dir)) {
     dir.create(output_dir, recursive = TRUE)
   }
 
   saveRDS(
-    res_final,
+    final_combined_result,
     file.path(output_dir, exposure_result_file)
   )
 
-  log_info("Saved results to {file.path(output_dir, exposure_result_file)}")
+  log_info("Saved {nrow(final_combined_result)} results to {file.path(output_dir, exposure_result_file)}")
+
+  pbdMPI::finalize() # Finalize MPI
+
   future::plan("sequential")
   log_info("Exposure Workflow completed successfully.")
 
   return(res_final)
-
 }


### PR DESCRIPTION
Support for running exposure on multiple nodes via MPI.

Test (command and relevant log entries):
```
mpiexec -n 2 Rscript scripts/main.R exposure --input_yml data-raw/shp_config.yml

INFO [2025-04-24 17:33:34] Loaded 116 species.
INFO [2025-04-24 17:33:34] Rank 0 processing 58 species.
INFO [2025-04-24 17:33:34] Loaded 116 species.
INFO [2025-04-24 17:33:34] Rank 1 processing 58 species.
...
INFO [2025-04-24 17:33:50] Exposure time calculation complete.
INFO [2025-04-24 17:33:50] Rank 0 has 663 results
INFO [2025-04-24 17:33:50] Rank 0 waiting to receive results from rank 1
INFO [2025-04-24 17:33:51] Exposure time calculation complete.
INFO [2025-04-24 17:33:51] Rank 1 sending results to rank 0
INFO [2025-04-24 17:33:51] Rank 0 received 1399 results from rank 1
INFO [2025-04-24 17:33:51] Saved 2062 results to outputs/exposure_result.rds
```
Container testing using `r-bio-div-base:1.3`

```
./docker_exposure.sh data-raw/shp_config.yml ./outputs
...
INFO [2025-04-29 21:42:45] Saved 2062 results to outputs/exposure_result.rds
```
