### PR TITLE
fix: Fix failing pbdMPI installation on MacOS

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -51,27 +51,6 @@ jobs:
         uses: mpi4py/setup-mpi@v1
         if: matrix.config.os == 'windows-latest'
 
-      # - name: Install MPI
-      #   if: matrix.config.os != 'windows-latest'
-      # - name: Install MPI
-      #   if: matrix.config.os != 'windows-latest'
-      #   shell: bash
-      #   run: |
-      #     if [[ "$RUNNER_OS" == "Linux" ]]; then
-      #       sudo apt-get update
-      #       sudo apt-get install -y openmpi-bin libopenmpi-dev
-      #     elif [[ "$RUNNER_OS" == "macOS" ]]; then
-      #       brew install open-mpi
-      #       echo "$(brew --prefix open-mpi)/bin" >> $GITHUB_PATH
-      #     fi
-
-      # - name: Install MS-MPI on Windows
-      #   if: matrix.config.os == 'windows-latest'
-      #   shell: powershell
-      #   run: |
-      #     choco install msmpi -y
-      #     echo "C:\Program Files\Microsoft MPI\Bin" | Out-File -Append -FilePath $env:GITHUB_PATH
-
       - name: Install required R packages
         run: |
           Rscript -e 'install.packages(c("magrittr", "usethis", "roxygen2"))'

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,8 +41,24 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - name: Setup MPI
-        uses: mpi4py/setup-mpi@v1
+      - name: Install MPI
+        if: matrix.config.os != 'windows-latest'
+        shell: bash
+        run: |
+          if [[ "$RUNNER_OS" == "Linux" ]]; then
+            sudo apt-get update
+            sudo apt-get install -y openmpi-bin libopenmpi-dev
+          elif [[ "$RUNNER_OS" == "macOS" ]]; then
+            brew install open-mpi
+            echo "$(brew --prefix open-mpi)/bin" >> $GITHUB_PATH
+          fi
+
+      - name: Install MS-MPI on Windows
+        if: matrix.config.os == 'windows-latest'
+        shell: powershell
+        run: |
+          choco install msmpi -y
+          echo "C:\Program Files\Microsoft MPI\Bin" | Out-File -Append -FilePath $env:GITHUB_PATH
 
       - name: Install required R packages
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -41,24 +41,36 @@ jobs:
           http-user-agent: ${{ matrix.config.http-user-agent }}
           use-public-rspm: true
 
-      - name: Install MPI
+      - name: Setup MPI
+        uses: mpi4py/setup-mpi@v1
+        with:
+          mpi: openmpi
         if: matrix.config.os != 'windows-latest'
-        shell: bash
-        run: |
-          if [[ "$RUNNER_OS" == "Linux" ]]; then
-            sudo apt-get update
-            sudo apt-get install -y openmpi-bin libopenmpi-dev
-          elif [[ "$RUNNER_OS" == "macOS" ]]; then
-            brew install open-mpi
-            echo "$(brew --prefix open-mpi)/bin" >> $GITHUB_PATH
-          fi
 
-      - name: Install MS-MPI on Windows
+      - name: Setup MPI
+        uses: mpi4py/setup-mpi@v1
         if: matrix.config.os == 'windows-latest'
-        shell: powershell
-        run: |
-          choco install msmpi -y
-          echo "C:\Program Files\Microsoft MPI\Bin" | Out-File -Append -FilePath $env:GITHUB_PATH
+
+      # - name: Install MPI
+      #   if: matrix.config.os != 'windows-latest'
+      # - name: Install MPI
+      #   if: matrix.config.os != 'windows-latest'
+      #   shell: bash
+      #   run: |
+      #     if [[ "$RUNNER_OS" == "Linux" ]]; then
+      #       sudo apt-get update
+      #       sudo apt-get install -y openmpi-bin libopenmpi-dev
+      #     elif [[ "$RUNNER_OS" == "macOS" ]]; then
+      #       brew install open-mpi
+      #       echo "$(brew --prefix open-mpi)/bin" >> $GITHUB_PATH
+      #     fi
+
+      # - name: Install MS-MPI on Windows
+      #   if: matrix.config.os == 'windows-latest'
+      #   shell: powershell
+      #   run: |
+      #     choco install msmpi -y
+      #     echo "C:\Program Files\Microsoft MPI\Bin" | Out-File -Append -FilePath $env:GITHUB_PATH
 
       - name: Install required R packages
         run: |

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,7 @@ Imports:
     arrow,
     stringr,
     glue,
-    pbdMPI,
+    pbdMPI
 Suggests:
     testthat (>= 3.0.0)
 Config/testthat/edition: 3


### PR DESCRIPTION
Use openmpi on ubuntu and MacOS during the cmd check pipeline. Mpich is the default for Mac but was giving some inconsistent results.