### PR TITLE
docs:update MPI instructions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -87,6 +87,14 @@ Rscript scripts/main.R exposure -i data-raw/shp_config.yml
 Rscript scripts/main.R exposure -i data-raw/bien_config.yml
 ```
 
+#### Running exposure workflow on multiple nodes via MPI:
+
+```bash
+mpiexec -n 2 Rscript scripts/main.R exposure --input_yml data-raw/shp_config.yml
+```
+
+Replace with `bien_config.yml` to run BIEN ranges
+
 #### Running conversion utilities:
 
 - .shp to .rds (see below on how to pass additional arguments)

--- a/README.md
+++ b/README.md
@@ -200,7 +200,13 @@ apptainer pull /mnt/biodiversityhorizons.sif docker://ghcr.io/uw-ssec/biodiversi
 ls -l /mnt/biodiversityhorizons.sif
 ```
 
-**Step 5: Run Apptainer shell and mount required directories**
+**Step 5: Using MPI on Hyak (Optional)**
+
+For MPI-based runs on Hyak, see
+[Step 5: Running on HPC (Hyak) with MPI](docs/running_on_hyak.md#step-5-running-on-hpc-hyak-with-mpi).
+
+**Step 6: Run Apptainer shell and mount required directories (If not using
+MPI)**
 
 ```
 apptainer shell --bind /mnt/data-raw:/home/biodiversity-horizons/data-raw,/mnt/outputs:/home/biodiversity-horizons/outputs /mnt/biodiversityhorizons.sif
@@ -208,7 +214,7 @@ apptainer shell --bind /mnt/data-raw:/home/biodiversity-horizons/data-raw,/mnt/o
 
 ### Inside Apptainer Shell:
 
-**Step 6: Move to the correct working directory**
+**Step 7: Move to the correct working directory**
 
 ```
 cd /home/biodiversity-horizons
@@ -225,7 +231,7 @@ ls -l /home/biodiversity-horizons/data-raw/
 ls -l /home/biodiversity-horizons/outputs/
 ```
 
-**Step 7: Run the R exposure calculation script (you can modify the arguments by
+**Step 8: Run the R exposure calculation script (you can modify the arguments by
 updating the shp_config.yml or bien_config.yml file)**
 
 ##### For SHP:

--- a/docs/running_on_hyak.md
+++ b/docs/running_on_hyak.md
@@ -136,7 +136,38 @@ Verify the download:
 ls -l /gscratch/scrubbed/<UWNetid>/basics/
 ```
 
-## Step 5: Run Apptainer with the Transferred Data
+## Step 5: Running on HPC (Hyak) with MPI
+
+(Skip to Step 6 if you don't want to use MPI)
+
+On high-performance clusters like Hyak, you can run the workflow using Apptainer
+and MPI to scale across multiple nodes or cores.
+
+#### 1. Allocate Resources with `salloc`
+
+Use the following example to allocate 2 nodes with 2 tasks (MPI ranks) each:
+
+```bash
+salloc --partition=ckpt-all --nodes=2 --ntasks=2 --cpus-per-task=2 --mem=10G --time=2:00:00
+```
+
+Make sure `--ntasks` matches the number of MPI ranks you plan to run.
+
+#### 2. After allocation, launch the workflow using mpiexec:
+
+```
+mpiexec -n 2 apptainer exec \
+  --pwd /home/biodiversity-horizons \
+  --bind /gscratch/scrubbed/<netid>/data-raw:/home/biodiversity-horizons/data-raw \
+  --bind /gscratch/scrubbed/<netid>/outputs:/home/biodiversity-horizons/outputs \
+  /gscratch/scrubbed/<netid>/basics/biodiversityhorizons_latest.sif \
+  Rscript scripts/main.R exposure -i data-raw/shp_config.yml --workers 2
+```
+
+You can use `bien_config.yml` in place of `shp_config.yml` to run the BIEN
+workflow.
+
+## Step 6: Run Apptainer with the Transferred Data (If not using MPI)
 
 - Start an Apptainer shell with the correct bind paths:
 
@@ -165,7 +196,7 @@ ls -l /home/biodiversity-horizons/data-raw/
 ls -l /home/biodiversity-horizons/outputs/
 ```
 
-## Step 6: Navigate to the Project Directory
+## Step 7: Navigate to the Project Directory
 
 Move to the `biodiversity-horizons` directory inside the container:
 
@@ -173,7 +204,7 @@ Move to the `biodiversity-horizons` directory inside the container:
 cd /home/biodiversity-horizons
 ```
 
-## Step 7: Run BIEN Species Conversion Utility (Optional: If want to process BIEN Ranges)
+## Step 8: Run BIEN Species Conversion Utility (Optional: If want to process BIEN Ranges)
 
 ```
 Rscript scripts/main.R convert_bienranges \
@@ -188,7 +219,7 @@ Rscript scripts/main.R convert_bienranges \
 After the command completes, you should see `.parquet` files inside
 `data-raw/bien_ranges/processed/`
 
-## Step 8: Run the Exposure Workflow Script
+## Step 9: Run the Exposure Workflow Script
 
 Run with Default Arguments in `config.yml`
 
@@ -204,7 +235,7 @@ For SHP:
 Rscript scripts/main.R exposure -i data-raw/shp_config.yml
 ```
 
-## Step 9: Exit the Container
+## Step 10: Exit the Container
 
 ```
 exit


### PR DESCRIPTION
This pull request updates the documentation to include instructions for running the workflow with MPI on the Hyak high-performance computing (HPC) cluster. 

### Documentation updates for MPI workflow:

* [`docs/running_on_hyak.md`](diffhunk://#diff-806de717c583f56d8081c785c1210e802864356f189fb06269fd7ced57722653L139-R170): Added a new section, "Step 5: Running on HPC (Hyak) with MPI," which includes instructions for allocating resources using `salloc` and running the workflow with `mpiexec`. This section provides details on scaling across multiple nodes or cores using MPI.